### PR TITLE
Add initial unit tests for core submodules

### DIFF
--- a/core/common/src/commonTest/kotlin/com/pidygb/mynasadailypics/core/common/ResultTest.kt
+++ b/core/common/src/commonTest/kotlin/com/pidygb/mynasadailypics/core/common/ResultTest.kt
@@ -1,0 +1,43 @@
+package com.pidygb.mynasadailypics.core.common
+
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class ResultTest {
+
+    @Test
+    fun `asResult emits Loading then Success for successful flow`() = runTest {
+        val flow = flow { emit("data") }
+        val results = flow.asResult().toList()
+
+        assertEquals(2, results.size)
+        assertIs<Result.Loading>(results[0])
+        assertIs<Result.Success<String>>(results[1])
+        assertEquals("data", (results[1] as Result.Success<String>).data)
+    }
+
+    @Test
+    fun `asResult emits Loading then Error for failing flow`() = runTest {
+        val exception = RuntimeException("Test exception")
+        val flow = flow<String> { throw exception }
+        val results = flow.asResult().toList()
+
+        assertEquals(2, results.size)
+        assertIs<Result.Loading>(results[0])
+        assertIs<Result.Error>(results[1])
+        assertEquals(exception, (results[1] as Result.Error).exception)
+    }
+
+    @Test
+    fun `asResult emits Loading then completes for empty flow`() = runTest {
+        val flow = flow<String> {}
+        val results = flow.asResult().toList()
+
+        assertEquals(1, results.size)
+        assertIs<Result.Loading>(results[0])
+    }
+}

--- a/core/data/src/commonTest/kotlin/com/pidygb/mynasadailypics/core/data/sample/SampleRepositoryImplTest.kt
+++ b/core/data/src/commonTest/kotlin/com/pidygb/mynasadailypics/core/data/sample/SampleRepositoryImplTest.kt
@@ -1,0 +1,49 @@
+package com.pidygb.mynasadailypics.core.data.sample
+
+import com.pidygb.mynasadailypics.core.data.sample.local.SampleLocalDataSource
+import com.pidygb.mynasadailypics.core.data.sample.remote.SampleRemoteDataSource
+import com.pidygb.mynasadailypics.core.model.Sample
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SampleRepositoryImplTest {
+
+    private lateinit var localDataSource: SampleLocalDataSource
+    private lateinit var remoteDataSource: SampleRemoteDataSource
+    private lateinit var repository: SampleRepositoryImpl
+
+    @BeforeTest
+    fun setUp() {
+        localDataSource = mockk(relaxed = true)
+        remoteDataSource = mockk(relaxed = true)
+        repository = SampleRepositoryImpl(localDataSource, remoteDataSource)
+    }
+
+    @Test
+    fun `samples flow should come from localDataSource`() = runTest {
+        val expectedSamples = listOf(Sample(id = "1", name = "Test Sample"))
+        coEvery { localDataSource.samples } returns flowOf(expectedSamples)
+
+        val actualSamples = repository.samples
+        actualSamples.collect {
+            assertEquals(expectedSamples, it)
+        }
+    }
+
+    @Test
+    fun `getSamples should fetch from remote and save to local`() = runTest {
+        val remoteSamples = listOf(Sample(id = "2", name = "Remote Sample"))
+        coEvery { remoteDataSource.getSamples() } returns remoteSamples
+
+        repository.getSamples()
+
+        coVerify { remoteDataSource.getSamples() }
+        coVerify { localDataSource.clearAndCreateSamples(remoteSamples) }
+    }
+}

--- a/core/datastore/src/commonTest/kotlin/com/pidygb/mynasadailypics/core/datastore/AppDatabaseTest.kt
+++ b/core/datastore/src/commonTest/kotlin/com/pidygb/mynasadailypics/core/datastore/AppDatabaseTest.kt
@@ -1,0 +1,111 @@
+package com.pidygb.mynasadailypics.core.datastore
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.pidygb.mynasadailypics.core.datastore.AppDatabase
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AppDatabaseTest {
+
+    private lateinit var driver: SqlDriver
+    private lateinit var database: AppDatabase
+    private lateinit var queries: SampleQueries
+
+    @BeforeTest
+    fun setup() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        AppDatabase.Schema.create(driver)
+        database = AppDatabase(driver)
+        queries = database.sampleQueries
+    }
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    @Test
+    fun `insertSample and selectAllSamples work correctly`() {
+        assertTrue(queries.selectAllSamples().executeAsList().isEmpty())
+
+        queries.insertSample(
+            date = "2023-01-01",
+            explanation = "Explanation 1",
+            hdUrl = "hdurl1.com",
+            mediaType = "image",
+            serviceVersion = "v1",
+            title = "Title 1",
+            url = "url1.com"
+        )
+
+        var samples = queries.selectAllSamples().executeAsList()
+        assertEquals(1, samples.size)
+        assertEquals("2023-01-01", samples[0].date)
+        assertEquals("Title 1", samples[0].title)
+
+        queries.insertSample(
+            date = "2023-01-02",
+            explanation = "Explanation 2",
+            hdUrl = "hdurl2.com",
+            mediaType = "image",
+            serviceVersion = "v1",
+            title = "Title 2",
+            url = "url2.com"
+        )
+
+        samples = queries.selectAllSamples().executeAsList()
+        assertEquals(2, samples.size)
+        // Samples should be ordered by date descending
+        assertEquals("2023-01-02", samples[0].date)
+        assertEquals("2023-01-01", samples[1].date)
+    }
+
+    @Test
+    fun `insertSample replaces existing sample with same date`() {
+        queries.insertSample(
+            date = "2023-01-01",
+            explanation = "Initial Explanation",
+            hdUrl = "initialhdurl.com",
+            mediaType = "image",
+            serviceVersion = "v1",
+            title = "Initial Title",
+            url = "initialurl.com"
+        )
+
+        var samples = queries.selectAllSamples().executeAsList()
+        assertEquals(1, samples.size)
+        assertEquals("Initial Title", samples[0].title)
+
+        queries.insertSample(
+            date = "2023-01-01",
+            explanation = "Updated Explanation",
+            hdUrl = "updatedhdurl.com",
+            mediaType = "image",
+            serviceVersion = "v1",
+            title = "Updated Title",
+            url = "updatedurl.com"
+        )
+
+        samples = queries.selectAllSamples().executeAsList()
+        assertEquals(1, samples.size)
+        assertEquals("Updated Title", samples[0].title)
+        assertEquals("Updated Explanation", samples[0].explanation)
+    }
+
+    @Test
+    fun `deleteAllSamples removes all samples`() {
+        queries.insertSample("2023-01-01", "E1", "h1", "image", "v1", "T1", "u1")
+        queries.insertSample("2023-01-02", "E2", "h2", "image", "v1", "T2", "u2")
+
+        var samples = queries.selectAllSamples().executeAsList()
+        assertEquals(2, samples.size)
+
+        queries.deleteAllSamples()
+        samples = queries.selectAllSamples().executeAsList()
+        assertTrue(samples.isEmpty())
+    }
+}


### PR DESCRIPTION
This commit introduces unit tests for several of the core submodules:

- core/common: Added unit tests for `Result.kt` to verify the behavior of the `asResult()` Flow extension.
- core/data: Added unit tests for `SampleRepositoryImpl.kt`. These tests use MockK (syntax-wise, actual dependency not added by me) to mock local and remote data sources and verify repository logic.
- core/datastore: Added unit tests for the SQLDelight queries defined in `AppDatabase.sq`. These tests use an in-memory JDBC SQLite driver (dependency not added by me) to test insert, select, and delete operations.

The following core submodules were examined but tests were not added:

- core/model: Contains only a simple data class (`Sample.kt`), which typically does not require explicit unit tests.
- core/network: Contains Koin dependency injection setup for a Ktor HttpClient. Testing this directly would involve testing DI or Ktor setup. Classes consuming this client (e.g., in `core/data`) are tested with mocks.
- core/ui: Contains a Jetpack Compose UI component (`PictureItem.kt`). Unit testing Compose components is limited; UI behavior or screenshot tests are more appropriate but are more complex and were considered out of scope for this initial pass.

Created necessary test directory structures (`commonTest`) for the modules where tests were added.

Note: This commit assumes that necessary testing dependencies (like MockK, SQLDelight test driver, Kotlin Test) are available in the project's build configuration. I did not modify any Gradle build files.