### PR TITLE
Add unit tests for core modules and GitHub workflow

### DIFF
--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -43,7 +43,7 @@ kotlin {
             implementation(libs.sqldelight.native.driver)
         }
         desktopMain.dependencies {
-            implementation(libs.sqldelight.driver)
+            implementation(libs.sqldelight.sqlite.driver)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -30,6 +30,10 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.turbine)
+            implementation(project.dependencies.platform(libs.koin.bom))
+            implementation(libs.koin.test)
+            implementation(libs.sqldelight.sqlite.driver) // This should be sqldelight.sqlite.driver
         }
         desktopMain.dependencies {
             implementation(libs.kotlinx.coroutinesSwing)

--- a/core/datastore/src/commonTest/kotlin/com/pidygb/mynasadailypics/core/datastore/SampleLocalDataSourceTest.kt
+++ b/core/datastore/src/commonTest/kotlin/com/pidygb/mynasadailypics/core/datastore/SampleLocalDataSourceTest.kt
@@ -1,0 +1,98 @@
+package com.pidygb.mynasadailypics.core.datastore
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import app.cash.turbine.test
+import com.pidygb.mynasadailypics.core.database.AppDatabase
+import com.pidygb.mynasadailypics.core.database.AppDatabaseQueries
+import com.pidygb.mynasadailypics.core.model.Sample
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
+import org.koin.test.inject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@ExperimentalCoroutinesApi
+class SampleLocalDataSourceTest : KoinTest {
+
+    private val sampleLocalDataSource: SampleLocalDataSource by inject()
+    private val queries: AppDatabaseQueries by inject()
+
+    @BeforeTest
+    fun setup() {
+        startKoin {
+            modules(
+                module {
+                    single<SqlDriver> {
+                        JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY).apply {
+                            AppDatabase.Schema.create(this)
+                        }
+                    }
+                    single { AppDatabase(get()).appDatabaseQueries }
+                    single<SampleLocalDataSource> { SampleLocalDataSourceImpl(get()) }
+                }
+            )
+        }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `test clearAndCreateSamples inserts new samples`() = runTest {
+        val samples = listOf(
+            Sample("2023-01-01", "Explanation 1", "hdurl1", "image", "v1", "Title 1", "url1"),
+            Sample("2023-01-02", "Explanation 2", "hdurl2", "image", "v1", "Title 2", "url2")
+        )
+
+        sampleLocalDataSource.clearAndCreateSamples(samples)
+
+        val dbSamples = queries.selectAllSamples().executeAsList()
+        assertEquals(2, dbSamples.size)
+        assertEquals("2023-01-01", dbSamples[0].date)
+        assertEquals("2023-01-02", dbSamples[1].date)
+    }
+
+    @Test
+    fun `test samples flow emits correct data`() = runTest {
+        val samples = listOf(
+            Sample("2023-01-01", "Explanation 1", "hdurl1", "image", "v1", "Title 1", "url1"),
+            Sample("2023-01-02", "Explanation 2", "hdurl2", "image", "v1", "Title 2", "url2")
+        )
+
+        sampleLocalDataSource.samples.test {
+            assertEquals(emptyList(), awaitItem()) // Initial empty list
+
+            sampleLocalDataSource.clearAndCreateSamples(samples)
+            val emittedSamples = awaitItem()
+            assertEquals(2, emittedSamples.size)
+            assertEquals("2023-01-01", emittedSamples[0].date)
+            assertEquals("2023-01-02", emittedSamples[1].date)
+        }
+    }
+
+    @Test
+    fun `test clearAndCreateSamples clears existing samples`() = runTest {
+        val initialSamples = listOf(
+            Sample("2023-01-01", "Explanation 1", "hdurl1", "image", "v1", "Title 1", "url1")
+        )
+        sampleLocalDataSource.clearAndCreateSamples(initialSamples)
+
+        val newSamples = listOf(
+            Sample("2023-01-02", "Explanation 2", "hdurl2", "image", "v1", "Title 2", "url2")
+        )
+        sampleLocalDataSource.clearAndCreateSamples(newSamples)
+
+        val dbSamples = queries.selectAllSamples().executeAsList()
+        assertEquals(1, dbSamples.size)
+        assertEquals("2023-01-02", dbSamples[0].date)
+    }
+}

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -28,6 +28,10 @@ kotlin {
         }
         commonTest.dependencies {
             api(libs.kotlin.test)
+            implementation(project.dependencies.platform(libs.koin.bom))
+            implementation(libs.koin.test)
+            implementation(libs.ktor.client.mock)
+            implementation(libs.turbine)
         }
     }
 }

--- a/core/network/src/commonTest/kotlin/com/pidygb/mynasadailypics/core/network/SampleRemoteDataSourceTest.kt
+++ b/core/network/src/commonTest/kotlin/com/pidygb/mynasadailypics/core/network/SampleRemoteDataSourceTest.kt
@@ -1,0 +1,92 @@
+package com.pidygb.mynasadailypics.core.network
+
+import com.pidygb.mynasadailypics.core.network.model.NetworkSample
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
+import org.koin.test.inject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@ExperimentalCoroutinesApi
+class SampleRemoteDataSourceTest : KoinTest {
+
+    private val sampleRemoteDataSource: SampleRemoteDataSource by inject()
+    private lateinit var mockEngine: MockEngine
+
+    @BeforeTest
+    fun setup() {
+        mockEngine = MockEngine { request ->
+            val responseHeaders = headersOf(HttpHeaders.ContentType, "application/json")
+            val samples = listOf(
+                NetworkSample("2023-01-01", "Explanation 1", "hdurl1", "image", "v1", "Title 1", "url1"),
+                NetworkSample("2023-01-02", "Explanation 2", "hdurl2", "image", "v1", "Title 2", "url2")
+            )
+            val json = Json.encodeToString(samples)
+            respond(json, HttpStatusCode.OK, responseHeaders)
+        }
+
+        startKoin {
+            modules(
+                module {
+                    single {
+                        HttpClient(mockEngine) {
+                            install(ContentNegotiation) {
+                                json(Json {
+                                    ignoreUnknownKeys = true
+                                    prettyPrint = true
+                                    isLenient = true
+                                })
+                            }
+                        }
+                    }
+                    single<SampleRemoteDataSource> { SampleRemoteDataSourceImpl(get()) }
+                }
+            )
+        }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `test getSamples returns correct data`() = runTest {
+        val samples = sampleRemoteDataSource.getSamples()
+
+        assertEquals(2, samples.size)
+        assertEquals("2023-01-01", samples[0].date)
+        assertEquals("Title 1", samples[0].title)
+        assertEquals("2023-01-02", samples[1].date)
+        assertEquals("Title 2", samples[1].title)
+    }
+
+    @Test
+    fun `test getSamples handles API error`() = runTest {
+        mockEngine.config.requestHandlers = listOf {
+            respondError(HttpStatusCode.InternalServerError)
+        }
+
+        try {
+            sampleRemoteDataSource.getSamples()
+            // Should throw an exception
+            assert(false) { "API error was not propagated" }
+        } catch (e: Exception) {
+            // Expected exception
+            assert(true)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ kotlinx-coroutines = "1.10.2"
 ktor = "3.2.1"
 sqlDelight = "2.1.0"
 coil = "3.2.0"
+turbine = "1.1.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -26,6 +27,7 @@ coil-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.re
 
 koin-bom = { module = "io.insert-koin:koin-bom", version = "4.1.0" }
 koin-core = { module = "io.insert-koin:koin-core" }
+koin-test = { module = "io.insert-koin:koin-test" }
 koin-compose = { module = "io.insert-koin:koin-compose" }
 koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel" }
 koin-compose-viewmodel-navigation = { module = "io.insert-koin:koin-compose-viewmodel-navigation" }
@@ -36,6 +38,7 @@ ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
@@ -43,8 +46,9 @@ kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version 
 sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqlDelight" }
 sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqlDelight" }
 sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqlDelight" }
-sqldelight-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqlDelight" }
+sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqlDelight" }
 sqldelight-coroutines-extensions = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqlDelight" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- Added test dependencies: Turbine, Koin-test, SQLDelight (for datastore), Ktor-client-mock (for network).
- Implemented unit tests for SampleLocalDataSource in :core:datastore.
  - Tests cover data insertion, retrieval, and flow emissions.
  - Used in-memory SQLite driver for testing.
- Implemented unit tests for SampleRemoteDataSource in :core:network.
  - Tests cover successful data fetching and API error handling.
  - Used Ktor's MockEngine for simulating network responses.
- Attempted to run all tests using `./gradlew allTests`.
- Encountered issues with Android SDK location:
  - Tried creating `local.properties` with various SDK paths (`/android-sdk`, `/opt/android/sdk`, `/usr/lib/android-sdk`).
  - Tried setting `ANDROID_HOME` and `ANDROID_SDK_ROOT` environment variables.
  - Tried modifying root `build.gradle.kts` to set SDK path programmatically.
- Currently stuck on resolving the Android SDK location issue, which prevents tests from running successfully.