### PR TITLE
feat: Add unit test for core:network module

### DIFF
--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -14,7 +14,11 @@ kotlin {
             api(libs.bundles.ktor)
         }
         commonTest.dependencies {
-            api(libs.kotlin.test)
+            implementation(project.dependencies.platform(libs.koin.bom))
+            implementation(libs.koin.test)
+            implementation(libs.kotlin.test)
+            implementation(libs.ktor.client.mock)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/core/network/src/commonTest/kotlin/com/pidygb/mynasadailypics/core/network/PicturesRemoteDataSourceImplTest.kt
+++ b/core/network/src/commonTest/kotlin/com/pidygb/mynasadailypics/core/network/PicturesRemoteDataSourceImplTest.kt
@@ -1,0 +1,72 @@
+package com.pidygb.mynasadailypics.core.network
+
+import com.pidygb.mynasadailypics.core.network.model.NetworkSample
+import io.ktor.client.engine.mock.*
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+class PicturesRemoteDataSourceImplTest {
+
+    private val mockData = listOf(
+        NetworkSample(
+            date = "2023-01-01",
+            explanation = "explanation1",
+            hdUrl = "hdurl1",
+            mediaType = "image",
+            serviceVersion = "v1",
+            title = "title1",
+            url = "url1"
+        ),
+        NetworkSample(
+            date = "2023-01-02",
+            explanation = "explanation2",
+            hdUrl = "hdurl2",
+            mediaType = "image",
+            serviceVersion = "v1",
+            title = "title2",
+            url = "url2"
+        )
+    )
+
+    @Test
+    fun `getPictures returns pictures when the call is successful`() = runTest {
+        val mockEngine = MockEngine {
+            respond(
+                content = Json.encodeToString(mockData),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val client = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                })
+            }
+        }
+        val dataSource = PicturesRemoteDataSourceImpl(client)
+        val pictures = dataSource.getPictures()
+        assertEquals(2, pictures.size)
+        assertEquals("title1", pictures[0].title)
+    }
+
+    @Test
+    fun `getPictures throws an exception when the call is unsuccessful`() = runTest {
+        val mockEngine = MockEngine {
+            respondError(HttpStatusCode.InternalServerError)
+        }
+        val client = HttpClient(mockEngine)
+        val dataSource = PicturesRemoteDataSourceImpl(client)
+        assertFails {
+            dataSource.getPictures()
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,11 +26,13 @@ coil-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.re
 
 koin-bom = { module = "io.insert-koin:koin-bom", version = "4.1.0" }
 koin-core = { module = "io.insert-koin:koin-core" }
+koin-test = { module = "io.insert-koin:koin-test" }
 koin-compose = { module = "io.insert-koin:koin-compose" }
 koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel" }
 koin-compose-viewmodel-navigation = { module = "io.insert-koin:koin-compose-viewmodel-navigation" }
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }


### PR DESCRIPTION
I have added a unit test for the `PicturesRemoteDataSourceImpl` class in the `:core:network` module. The test uses a mock `HttpClient` to simulate network responses and verifies that the `getPictures` method returns the expected results in both success and error cases.

I also updated the `build.gradle.kts` and `gradle/libs.versions.toml` files to include the necessary testing dependencies.